### PR TITLE
add config options to config class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,26 @@
 # Class: bitlbee::config
 #
 # Class which configures the bitlbee service
-class bitlbee::config {
+class bitlbee::config (
+  $runmode         = $::bitlbee::runmode,
+  $user            = $::bitlbee::user,
+  $daemoninterface = $::bitlbee::daemoninterface,
+  $daemonport      = $::bitlbee::daemonport,
+  $clientinterface = $::bitlbee::clientinterface,
+  $authmode        = $::bitlbee::authmode,
+  $authpassword    = $::bitlbee::authpassword,
+  $operpassword    = $::bitlbee::operpassword,
+  $hostname        = $::bitlbee::hostname,
+  $motdfile        = $::bitlbee::motdfile,
+  $configdir       = $::bitlbee::configdir,
+  $pinginterval    = $::bitlbee::pinginterval,
+  $pingtimeout     = $::bitlbee::pingtimeout,
+  $proxy           = $::bitlbee::proxy,
+  $protocols       = $::bitlbee::protocols,
+  $ssl             = $::bitlbee::ssl,
+  $cafile          = $::bitlbee::cafile,
+  $private         = $::bitlbee::private,
+) {
 
   file { "${bitlbee::configdir}/bitlbee.conf":
     ensure  => file,


### PR DESCRIPTION
Without this no options get set in the config file (puppet 4.3.2 on archlinux)